### PR TITLE
Fix unsupported YNAB loan account type breaking YNAB client

### DIFF
--- a/pynab_monzo/controllers/webhook.py
+++ b/pynab_monzo/controllers/webhook.py
@@ -58,6 +58,6 @@ def handle_incoming_transaction(json):
 
     outgoing_json = translate_monzo_to_ynab(json)
     logger.debug(f"Translated Monzo transaction to: {outgoing_json}")
-    client.create_transaction(client._LAST_USED, outgoing_json)
+    client.create_transaction(outgoing_json)
 
     return http.HTTPStatus.CREATED

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,5 +54,4 @@ typing-extensions==3.7.4.3
 urllib3==1.25.9
 wcwidth==0.1.9
 Werkzeug==1.0.1
-ynab==0.0.2
 zipp==3.1.0

--- a/tests/ynab_client_test.py
+++ b/tests/ynab_client_test.py
@@ -8,7 +8,7 @@ from pynab_monzo.ynab import YnabClient
 @mark.integration
 def test_ynab_client_can_connect():
     testClient = YnabClient()
-    assert testClient.budgets().data is not None
+    assert testClient.budgets()["data"] is not None
 
 
 def test_ynab_client_can_convert_positive_amounts_to_milliunits():


### PR DESCRIPTION
The OpenAPI wrapper previously used for communicating with the YNAB API
has not been updated since YNAB added a new type of loan account. This
resulted in exceptions being thrown during enumeration of the different
accounts in the last used budget.

The interaction with the YNAB API was probably not extensive or complex
enough to warrant using the wrapper in the first place, so getting rid
of it in favour of just using requests seemed like the best course of
action.

Fixes #8 .